### PR TITLE
Refactor window label wait loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -694,12 +694,8 @@ class Generic:
 
     # Wait for window label variable
     def waitWindowLabelVar():
-        while True:
-            try: 
-                windowLabel 
-                break
-            except: 
-                pass
+        while 'windowLabel' not in globals():
+            time.sleep(0.1)
 
     # Open settings file
     def openSettings():


### PR DESCRIPTION
## Summary
- Replace busy loop in `waitWindowLabelVar` with a check for `windowLabel` in globals
- Ensure `time` module is imported for the new sleep call

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68acad2370d48325be055466ee7b4799