### PR TITLE
Handle push-to-talk with press and release

### DIFF
--- a/main.py
+++ b/main.py
@@ -673,11 +673,17 @@ class Hotkeys:
             logging.debug(f"Loaded stop recording hotkey: {settings.hotkeyStopRecording}")
 
         def pushToTalk():
-            keyboard.add_hotkey(
-                settings.hotkeyStartRecording,
-                speechConverter.start
+            keyboard.on_press_key(
+                settings.hotkeyPushToTalk,
+                lambda event: speechConverter.start()
             )
-            logging.debug(f"Loaded push-to-talk recording hotkey: {settings.hotkeyStartRecording}")
+            keyboard.on_release_key(
+                settings.hotkeyPushToTalk,
+                lambda event: speechConverter.stop()
+            )
+            logging.debug(
+                f"Loaded push-to-talk recording hotkey: {settings.hotkeyPushToTalk}"
+            )
 
 
         def allKeys():


### PR DESCRIPTION
## Summary
- Trigger recording start and stop on push-to-talk key press/release.
- Use `settings.hotkeyPushToTalk` for push-to-talk configuration.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68adfbf5cfe083258f31cecffbf6ef89