### PR TITLE
Exclude HTML files from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude HTML files from GitHub language statistics
+*.html linguist-generated


### PR DESCRIPTION
## Summary
- prevent HTML files from affecting GitHub language statistics by marking them as generated

## Testing
- `VOICEKB_DRYRUN=1 VOICEKB_HEADLESS=1 pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file; DisplayNameError: Bad display name "" )*

------
https://chatgpt.com/codex/tasks/task_e_68b0d3245540832599b12d046f4718df